### PR TITLE
fix deprecation warnings for julia v0.6

### DIFF
--- a/src_julia/fem_poisson.jl
+++ b/src_julia/fem_poisson.jl
@@ -152,7 +152,7 @@ function rectgrid( n_cx = 10, n_cy = 0, xp = [0 1;0 1] )
     if isempty(y)
         y = linspace( y0, y0+ly, n_py )
     end
-    yy = Array(Float64,n_p)
+    yy = Array{Float64}(n_p)
     for j = 1:n_py
         yy[(j-1)*n_px+1:j*n_px] = y[j]
     end
@@ -161,7 +161,7 @@ function rectgrid( n_cx = 10, n_cy = 0, xp = [0 1;0 1] )
 
     # Cell cell connectivities (grid points ordered counterclockwise for
     # each cell starting with the bottom left vertex as the first node).
-    c = Array(Int64,4,n_c)
+    c = Array{Int64}(4,n_c)
     ic = 0
     for j = 1:n_py-1
         for i = 1:n_px-1
@@ -174,7 +174,7 @@ function rectgrid( n_cx = 10, n_cy = 0, xp = [0 1;0 1] )
     end
 
     # Grid cell adjacencies.
-    a = Array(Int64,4,n_c)
+    a = Array{Int64}(4,n_c)
     ic = 0
     for j = 1:n_cy
         for i = 1:n_cx
@@ -204,7 +204,7 @@ function rectgrid( n_cx = 10, n_cy = 0, xp = [0 1;0 1] )
     s = ones(Int64,1,n_c)
 
     # Output.
-    grid = Array(Any,5)
+    grid = Array{Any}(5)
 
     grid[1] = p
     grid[2] = c


### PR DESCRIPTION
I noticed that running the benchmark in the current Julia release (v0.6.2) throws a number of deprecation warnings. This PR fixes those warnings. 

Also, can I ask what the correct settings for `testrun_param.txt` are to generate the output saved in the `output` folder? The committed version of that file only generates the `32` and `64` rows. I *think* that just fixing the deprecations and using Julia v0.6.2 gives a noticeable speedup (even on an ancient 2012 laptop), but I want to make sure I'm running the correct benchmark. 